### PR TITLE
Add optim() method option

### DIFF
--- a/R/betabin.R
+++ b/R/betabin.R
@@ -1,7 +1,8 @@
 ### fitting function
 betabin <- function(formula, random, data = NULL, link = c("logit", "cloglog"), 
                     phi.ini = NULL, warnings = FALSE, na.action = na.omit, 
-                    fixpar = list(), hessian = TRUE, control = list(maxit = 2000), ...){
+                    fixpar = list(), hessian = TRUE, control = list(maxit = 2000),
+                    method="Nelder-Mead", ...){
 # get the call
   CALL <- mf <- match.call(expand.dots = FALSE)
 
@@ -138,7 +139,7 @@ betabin <- function(formula, random, data = NULL, link = c("logit", "cloglog"),
     val <- withCallingHandlers(expr, warning = wHandler)
     list(value = val, warnings = myWarnings)
     }
-  reswarn <- withWarnings(optim(par = param.ini, fn = minuslogL, hessian = hessian, control = control, ...))
+  reswarn <- withWarnings(optim(par = param.ini, fn = minuslogL, hessian = hessian, control = control, method = method, ...))
   res <- reswarn$value
   if(warnings){
     if(length(reswarn$warnings) > 0){


### PR DESCRIPTION
Allow for the specification of a different optimization method in the call to optim() by setting method equal to something other than the default ("Nelder-Mead").

This is desirable in cases where the convergence of betabin() is sensitive to the optimization method chosen.  
